### PR TITLE
Prevent core dumps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ strip = "symbols"
 
 [dependencies]
 getopts = "0.2"
-nix = { version = "0.29", features = ["fs", "process", "user"] }
+nix = { version = "0.29", features = ["fs", "process", "user", "resource"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use getopts::Options;
-use nix::sys::resource::{setrlimit, Resource, Rlim};
+use nix::sys::resource::{self, Resource, rlim_t};
 use nix::sys::stat::{self, Mode};
 use nix::unistd::{self, Uid, Gid, User};
 use std::{env, process};
@@ -58,7 +58,7 @@ fn main() {
         "safe" | _ => build_safe_env(new_euid),
     };
 
-    if let Err(err) = setrlimit(Resource::RLIMIT_CORE, Rlim::from_raw(0), Rlim::from_raw(0)) {
+    if let Err(err) = resource::setrlimit(Resource::RLIMIT_CORE, 0 as rlim_t, 0 as rlim_t) {
         eprintln!("{}: {}", path.display(), err);
         process::exit(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use getopts::Options;
+use nix::sys::resource::{setrlimit, Resource, Rlim};
 use nix::sys::stat::{self, Mode};
 use nix::unistd::{self, Uid, Gid, User};
 use std::{env, process};
@@ -56,6 +57,11 @@ fn main() {
         },
         "safe" | _ => build_safe_env(new_euid),
     };
+
+    if let Err(err) = setrlimit(Resource::RLIMIT_CORE, Rlim::from_raw(0), Rlim::from_raw(0)) {
+        eprintln!("{}: {}", path.display(), err);
+        process::exit(1);
+    }
 
     if let Err(err) = unistd::setresgid(new_rgid, new_egid, Gid::from_raw(u32::MAX)) {
         eprintln!("{}: {}", path.display(), err);


### PR DESCRIPTION
When a process is attached to a terminal, pressing `Ctrl+\` sends it a SIGQUIT signal. The default action for SIGQUIT is to both terminate the process and generate a core dump, which contains the program’s memory at the time of the crash. For privileged or setuid programs, this is dangerous — a user could intentionally trigger a core dump and gain access to sensitive in-memory data such as passwords, environment variables, or internal state. 

This change prevents that by disabling core-dump generation entirely (setting RLIMIT_CORE to zero). That way, even if SIGQUIT or another fatal signal occurs, no core file will be written.