### PR TITLE
Handle missing passwd entries in safe env

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ fn build_safe_env(uid: Uid) -> Vec<CString> {
         .to_string();
     env_vars.push(CString::new(path_value).unwrap());
 
-    match User::from_uid(uid).unwrap_or_else(|_| panic!("Failed to look up user by uid: {}", uid)) {
+    match User::from_uid(uid).ok().flatten() {
         Some(user) => {
             env_vars.push(CString::new(format!("USER={}", user.name)).unwrap());
             env_vars.push(CString::new(format!("LOGNAME={}", user.name)).unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,7 @@ fn build_safe_env(uid: Uid) -> Vec<CString> {
     env_vars.push(CString::new(path_value).unwrap());
 
     env_vars.push(CString::new(format!("USER={}", target_user.name)).unwrap());
+    env_vars.push(CString::new(format!("LOGNAME={}", target_user.name)).unwrap());
     env_vars.push(CString::new(format!("HOME={}", target_user.dir.display())).unwrap());
     env_vars.push(CString::new(format!("SHELL={}", target_user.shell.display())).unwrap());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,6 @@ use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 
-struct SafeEnvUser {
-    name: String,
-    dir: PathBuf,
-    shell: PathBuf,
-}
-
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() <= 1 {
@@ -158,19 +152,6 @@ fn check_path_in_nosuid_mount(path: &Path) -> io::Result<bool> {
 fn build_safe_env(uid: Uid) -> Vec<CString> {
     let mut env_vars = Vec::new();
 
-    let target_user = User::from_uid(uid)
-        .unwrap_or_else(|_| panic!("Failed to look up user by uid: {}", uid))
-        .map(|user| SafeEnvUser {
-            name: user.name,
-            dir: user.dir,
-            shell: user.shell,
-        })
-        .unwrap_or_else(|| SafeEnvUser {
-            name: format!("#{}", uid.as_raw()),
-            dir: PathBuf::from("/"),
-            shell: PathBuf::from("/bin/sh"),
-        });
-
     let init_environ = std::fs::read("/proc/1/environ")
         .expect("Failed to read init environ");
     let path_value = String::from_utf8_lossy(&init_environ)
@@ -180,10 +161,20 @@ fn build_safe_env(uid: Uid) -> Vec<CString> {
         .to_string();
     env_vars.push(CString::new(path_value).unwrap());
 
-    env_vars.push(CString::new(format!("USER={}", target_user.name)).unwrap());
-    env_vars.push(CString::new(format!("LOGNAME={}", target_user.name)).unwrap());
-    env_vars.push(CString::new(format!("HOME={}", target_user.dir.display())).unwrap());
-    env_vars.push(CString::new(format!("SHELL={}", target_user.shell.display())).unwrap());
+    match User::from_uid(uid).unwrap_or_else(|_| panic!("Failed to look up user by uid: {}", uid)) {
+        Some(user) => {
+            env_vars.push(CString::new(format!("USER={}", user.name)).unwrap());
+            env_vars.push(CString::new(format!("LOGNAME={}", user.name)).unwrap());
+            env_vars.push(CString::new(format!("HOME={}", user.dir.display())).unwrap());
+            env_vars.push(CString::new(format!("SHELL={}", user.shell.display())).unwrap());
+        }
+        None => {
+            env_vars.push(CString::new(format!("USER=#{}", uid.as_raw())).unwrap());
+            env_vars.push(CString::new(format!("LOGNAME=#{}", uid.as_raw())).unwrap());
+            env_vars.push(CString::new("HOME=/").unwrap());
+            env_vars.push(CString::new("SHELL=/bin/sh").unwrap());
+        }
+    }
 
     let term = std::env::var("TERM").unwrap_or_else(|_| "unknown".to_string());
     env_vars.push(CString::new(format!("TERM={}", term)).unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,12 @@ use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 
+struct SafeEnvUser {
+    name: String,
+    dir: PathBuf,
+    shell: PathBuf,
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() <= 1 {
@@ -153,8 +159,17 @@ fn build_safe_env(uid: Uid) -> Vec<CString> {
     let mut env_vars = Vec::new();
 
     let target_user = User::from_uid(uid)
-        .expect(&format!("Failed to look up user by uid: {}", uid))
-        .expect(&format!("No user found for uid: {}", uid));
+        .unwrap_or_else(|_| panic!("Failed to look up user by uid: {}", uid))
+        .map(|user| SafeEnvUser {
+            name: user.name,
+            dir: user.dir,
+            shell: user.shell,
+        })
+        .unwrap_or_else(|| SafeEnvUser {
+            name: format!("#{}", uid.as_raw()),
+            dir: PathBuf::from("/"),
+            shell: PathBuf::from("/bin/sh"),
+        });
 
     let init_environ = std::fs::read("/proc/1/environ")
         .expect("Failed to read init environ");

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -46,3 +46,17 @@ def test_opt_environ_all(run_program):
         """,
         env={"PATH": "/dangerous"},
     ) == "/dangerous"
+
+
+def test_env_passwd_fallback(run_program):
+    result = run_program(
+        """
+        #!/usr/bin/exec-suid -- /bin/bash -p
+
+        printf '%s\\n%s\\n%s\\n' "$USER" "$HOME" "$SHELL"
+        """,
+        script_permissions=0o555,
+        user=12345,
+        group=1000,
+    )
+    assert result == "#12345\n/\n/bin/sh"

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -63,7 +63,7 @@ def test_env_passwd_fallback(run_program):
 
 def test_env_missing_passwd_fallback(run_program):
     passwd_path = Path("/etc/passwd")
-    backup_path = Path("/etc/passwd.exec-suid-test")
+    backup_path = Path("/etc/passwd.bkup")
     passwd_path.rename(backup_path)
     try:
         assert run_program(

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -53,10 +53,10 @@ def test_env_passwd_fallback(run_program):
         """
         #!/usr/bin/exec-suid -- /bin/bash -p
 
-        printf '%s\\n%s\\n%s\\n' "$USER" "$HOME" "$SHELL"
+        printf '%s\\n%s\\n%s\\n%s\\n' "$USER" "$LOGNAME" "$HOME" "$SHELL"
         """,
         script_permissions=0o555,
         user=12345,
         group=1000,
     )
-    assert result == "#12345\n/\n/bin/sh"
+    assert result == "#12345\n#12345\n/\n/bin/sh"

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 
 def test_env_path(run_program):
@@ -59,4 +60,24 @@ def test_env_passwd_fallback(run_program):
         user=12345,
         group=1000,
     )
+    assert result == "#12345\n#12345\n/\n/bin/sh"
+
+
+def test_env_missing_passwd_fallback(run_program):
+    passwd_path = Path("/etc/passwd")
+    backup_path = Path("/etc/passwd.exec-suid-test")
+    passwd_path.rename(backup_path)
+    try:
+        result = run_program(
+            """
+            #!/usr/bin/exec-suid -- /bin/bash -p
+
+            printf '%s\\n%s\\n%s\\n%s\\n' "$USER" "$LOGNAME" "$HOME" "$SHELL"
+            """,
+            script_permissions=0o555,
+            user=12345,
+            group=1000,
+        )
+    finally:
+        backup_path.rename(passwd_path)
     assert result == "#12345\n#12345\n/\n/bin/sh"

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -50,7 +50,7 @@ def test_opt_environ_all(run_program):
 
 
 def test_env_passwd_fallback(run_program):
-    result = run_program(
+    assert run_program(
         """
         #!/usr/bin/exec-suid -- /bin/bash -p
 
@@ -59,8 +59,7 @@ def test_env_passwd_fallback(run_program):
         script_permissions=0o555,
         user=12345,
         group=1000,
-    )
-    assert result == "#12345\n#12345\n/\n/bin/sh"
+    ) == "#12345\n#12345\n/\n/bin/sh"
 
 
 def test_env_missing_passwd_fallback(run_program):
@@ -68,7 +67,7 @@ def test_env_missing_passwd_fallback(run_program):
     backup_path = Path("/etc/passwd.exec-suid-test")
     passwd_path.rename(backup_path)
     try:
-        result = run_program(
+        assert run_program(
             """
             #!/usr/bin/exec-suid -- /bin/bash -p
 
@@ -77,7 +76,6 @@ def test_env_missing_passwd_fallback(run_program):
             script_permissions=0o555,
             user=12345,
             group=1000,
-        )
+        ) == "#12345\n#12345\n/\n/bin/sh"
     finally:
         backup_path.rename(passwd_path)
-    assert result == "#12345\n#12345\n/\n/bin/sh"

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -58,7 +58,6 @@ def test_env_passwd_fallback(run_program):
         """,
         script_permissions=0o555,
         user=12345,
-        group=1000,
     ) == "#12345\n#12345\n/\n/bin/sh"
 
 
@@ -75,7 +74,6 @@ def test_env_missing_passwd_fallback(run_program):
             """,
             script_permissions=0o555,
             user=12345,
-            group=1000,
         ) == "#12345\n#12345\n/\n/bin/sh"
     finally:
         backup_path.rename(passwd_path)


### PR DESCRIPTION
Fixes the case where /etc/passwd entry for the user is missing, or /etc/passwd does not exist.

We follow the same behavior as `sudo` defaults (e.g. `USER=#<uid>`, `HOME=/`, `SHELL=/bin/sh`).