### PR TITLE
Replace exec-suid environ modes with env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,25 +99,21 @@ This may be necessary if the interpreter you are using automatically sets the ef
 
 This also has implications for the ["dumpable" process attribute](https://man7.org/linux/man-pages/man2/PR_SET_DUMPABLE.2const.html) which may be relevant in some contexts (e.g., namespaces, ptrace).
 
-### Environment Handling (`--environ`)
+### Environment Handling (`--env`)
 
 By default, `exec-suid` carefully controls the environment variables passed to the invoked script to mitigate potential security risks.
-However, depending on your use case, you can customize this behavior using the `--environ` option:
 
-- **`safe` (default)**: Restricts environment variables to a safe subset:
-  - Inherited from init process (pid 1): `PATH`.
-  - From (new) effective user's `/etc/passwd` entry: `USER`, `HOME`, `SHELL`.
-  - Preserved if set, otherwise default values: `TERM` (default: `unknown`), `LANG` (default: `C.UTF-8`).
-  - Preserved if set, otherwise unset: `LANGUAGE`, `TZ`, `DISPLAY`, `LS_COLORS`, and all `LC_*` variables.
-  - All other variables unset.
+The default environment is restricted to a safe subset:
 
-- **`none`**: All environment variables are unset.
+- `PATH` is read from `/etc/environment`. If `/etc/environment` does not set `PATH`, `exec-suid` uses `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`.
+- From the new effective user's `/etc/passwd` entry: `USER`, `LOGNAME`, `HOME`, and `SHELL`.
+- Preserved from the caller if set, otherwise default values: `TERM` (default: `unknown`), `LANG` (default: `C.UTF-8`).
+- Preserved from the caller if set, otherwise unset: `LANGUAGE`, `TZ`, `DISPLAY`, `LS_COLORS`, and all `LC_*` variables.
+- All other variables unset.
 
-- **`all`**: All environment variables are preserved. This mode is **extremely dangerous**, since it allows a malicious user to control dangerous environment variables, such as `PATH` or `LD_PRELOAD`, which can lead to arbitrary code execution, or otherwise dramatically alter the behavior of the script in unexpected ways.
+Set additional environment variables in the shebang with repeated `--env KEY=VALUE` options; these override the default safe environment.
 
 For example:
 ```
-#!/usr/bin/exec-suid --environ=none -- /usr/bin/python3 -I
+#!/usr/bin/exec-suid --env PATH=/usr/bin:/bin --env APP_MODE=production -- /usr/bin/python3 -I
 ```
-
-This would run your python script with no inherited environment variables.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,13 @@ use nix::sys::resource::{self, Resource, rlim_t};
 use nix::sys::stat::{self, Mode};
 use nix::unistd::{self, Uid, Gid, User};
 use std::{env, process};
+use std::collections::BTreeMap;
 use std::ffi::CString;
 use std::fs::File;
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, Read};
 use std::path::{Path, PathBuf};
+
+const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -31,7 +34,9 @@ fn main() {
 
     let mut opts = Options::new();
     opts.optflag("", "real", "Set real user and group IDs");
+    // Deprecated: kept temporarily for compatibility. New scripts should rely on the safe default and --env overrides.
     opts.optopt("", "environ", "Environment policy: safe (default), none, or all", "MODE");
+    opts.optmulti("", "env", "Set an environment variable in the invoked script", "KEY=VALUE");
     let matches = opts.parse(&exec_argv[1..]).unwrap();
 
     script_argv.push(path.to_str().unwrap().to_string());
@@ -48,15 +53,16 @@ fn main() {
     let new_egid = if mode.contains(Mode::S_ISGID) { Gid::from_raw(stat.st_gid) } else { real_gid };
     let (new_ruid, new_rgid) = if matches.opt_present("real") { (new_euid, new_egid) } else { (real_uid, real_gid) };
 
-    let env: Vec<CString> = match matches.opt_str("environ").unwrap_or_else(|| "safe".to_string()).as_str() {
-        "none" => Vec::new(),
-        "all" => {
-            env::vars()
-                .map(|(key, value)| CString::new(format!("{}={}", key, value)).unwrap())
-                .collect()
-        },
-        "safe" | _ => build_safe_env(new_euid),
-    };
+    let env = match matches.opt_str("environ").unwrap_or_else(|| "safe".into()).as_str() {
+        "none" => Ok(Vec::new()),
+        "all" => env::vars()
+            .map(|(key, value)| CString::new(format!("{}={}", key, value)).map_err(|_| "environment contains NUL byte".to_string()))
+            .collect(),
+        "safe" | _ => build_safe_env(new_euid, &matches.opt_strs("env")),
+    }.unwrap_or_else(|err| {
+        eprintln!("{}: {}", path.display(), err);
+        process::exit(1);
+    });
 
     if let Err(err) = resource::setrlimit(Resource::RLIMIT_CORE, 0 as rlim_t, 0 as rlim_t) {
         eprintln!("{}: {}", path.display(), err);
@@ -149,43 +155,77 @@ fn check_path_in_nosuid_mount(path: &Path) -> io::Result<bool> {
     }
 }
 
-fn build_safe_env(uid: Uid) -> Vec<CString> {
-    let mut env_vars = Vec::new();
-
-    let init_environ = std::fs::read("/proc/1/environ")
-        .expect("Failed to read init environ");
-    let path_value = String::from_utf8_lossy(&init_environ)
-        .split('\0')
-        .find(|s| s.starts_with("PATH="))
-        .expect("PATH not found in init environ")
-        .to_string();
-    env_vars.push(CString::new(path_value).unwrap());
+fn build_safe_env(uid: Uid, env_overrides: &[String]) -> Result<Vec<CString>, String> {
+    let mut env_vars: BTreeMap<String, String> = BTreeMap::new();
 
     match User::from_uid(uid).ok().flatten() {
         Some(user) => {
-            env_vars.push(CString::new(format!("USER={}", user.name)).unwrap());
-            env_vars.push(CString::new(format!("LOGNAME={}", user.name)).unwrap());
-            env_vars.push(CString::new(format!("HOME={}", user.dir.display())).unwrap());
-            env_vars.push(CString::new(format!("SHELL={}", user.shell.display())).unwrap());
+            env_vars.insert("USER".into(), user.name.clone());
+            env_vars.insert("LOGNAME".into(), user.name);
+            env_vars.insert("HOME".into(), user.dir.display().to_string());
+            env_vars.insert("SHELL".into(), user.shell.display().to_string());
         }
         None => {
-            env_vars.push(CString::new(format!("USER=#{}", uid.as_raw())).unwrap());
-            env_vars.push(CString::new(format!("LOGNAME=#{}", uid.as_raw())).unwrap());
-            env_vars.push(CString::new("HOME=/").unwrap());
-            env_vars.push(CString::new("SHELL=/bin/sh").unwrap());
+            env_vars.insert("USER".into(), format!("#{}", uid.as_raw()));
+            env_vars.insert("LOGNAME".into(), format!("#{}", uid.as_raw()));
+            env_vars.insert("HOME".into(), "/".into());
+            env_vars.insert("SHELL".into(), "/bin/sh".into());
         }
     }
 
-    let term = std::env::var("TERM").unwrap_or_else(|_| "unknown".to_string());
-    env_vars.push(CString::new(format!("TERM={}", term)).unwrap());
-    let lang = std::env::var("LANG").unwrap_or_else(|_| "C.UTF-8".to_string());
-    env_vars.push(CString::new(format!("LANG={}", lang)).unwrap());
+    let term = std::env::var("TERM").unwrap_or_else(|_| "unknown".into());
+    env_vars.insert("TERM".into(), term);
+    let lang = std::env::var("LANG").unwrap_or_else(|_| "C.UTF-8".into());
+    env_vars.insert("LANG".into(), lang);
 
     for (key, value) in std::env::vars() {
         if ["LANGUAGE", "TZ", "DISPLAY", "LS_COLORS"].contains(&key.as_str()) || key.starts_with("LC_") {
-            env_vars.push(CString::new(format!("{}={}", key, value)).unwrap());
+            env_vars.insert(key, value);
         }
     }
 
+    for item in env_overrides {
+        let (key, value) = item
+            .split_once('=')
+            .ok_or_else(|| format!("--env requires KEY=VALUE: {item}"))?;
+        if key.is_empty() || key.as_bytes().contains(&0) || key.as_bytes().contains(&b'=') {
+            return Err(format!("invalid environment variable name: {key}"));
+        }
+        env_vars.insert(key.to_string(), value.to_string());
+    }
+
+    if !env_vars.contains_key("PATH") {
+        env_vars.insert("PATH".into(), environment_file_path().unwrap_or_else(|| DEFAULT_PATH.into()));
+    }
+
     env_vars
+        .into_iter()
+        .map(|(key, value)| CString::new(format!("{}={}", key, value)).map_err(|_| "environment contains NUL byte".to_string()))
+        .collect()
+}
+
+fn environment_file_path() -> Option<String> {
+    let mut data = String::new();
+    File::open("/etc/environment").ok()?.read_to_string(&mut data).ok()?;
+    data.lines().find_map(|line| {
+        let mut line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            return None;
+        }
+        if let Some(rest) = line.strip_prefix("export ") {
+            line = rest.trim_start();
+        }
+        line = line.split_once('#').map(|(value, _)| value).unwrap_or(line).trim_end();
+        let (key, value) = line.split_once('=')?;
+        if key.trim() != "PATH" {
+            return None;
+        }
+        let value = value.trim();
+        Some(if let Some(quote) = value.chars().next().filter(|quote| *quote == '"' || *quote == '\'') {
+            let value = &value[1..];
+            value.strip_suffix(quote).unwrap_or(value).to_string()
+        } else {
+            value.to_string()
+        })
+    })
 }

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -2,6 +2,9 @@ import os
 from pathlib import Path
 
 
+DEFAULT_SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+
 def test_env_path(run_program):
     result = run_program(
         """
@@ -12,7 +15,82 @@ def test_env_path(run_program):
         env={"PATH": "/dangerous"},
     )
     assert result != "/dangerous"
-    assert result == os.environ.get("PATH")
+
+
+def test_env_path_from_etc_environment(run_program):
+    environ_path = Path("/etc/environment")
+    backup = environ_path.read_text() if environ_path.exists() else None
+    environ_path.write_text(
+        """
+        # comment
+        export FOO=/ignored
+        export PATH="/safe/from/etc:/usr/bin:/bin" # comment
+        """
+    )
+    try:
+        assert run_program(
+            """
+            #!/usr/bin/exec-suid -- /bin/bash -p
+
+            printf '%s\\n' "$PATH"
+            """,
+            env={"PATH": "/dangerous"},
+        ) == "/safe/from/etc:/usr/bin:/bin"
+    finally:
+        if backup is None:
+            environ_path.unlink(missing_ok=True)
+        else:
+            environ_path.write_text(backup)
+
+
+def test_env_path_default(run_program):
+    environ_path = Path("/etc/environment")
+    backup = environ_path.read_text() if environ_path.exists() else None
+    environ_path.unlink(missing_ok=True)
+    try:
+        assert run_program(
+            """
+            #!/usr/bin/exec-suid -- /bin/bash -p
+
+            printf '%s\\n' "$PATH"
+            """,
+            env={"PATH": "/dangerous"},
+        ) == DEFAULT_SAFE_PATH
+    finally:
+        if backup is not None:
+            environ_path.write_text(backup)
+
+
+def test_opt_env_path(run_program):
+    assert run_program(
+        """
+        #!/usr/bin/exec-suid --env PATH=/custom/bin:/usr/bin -- /bin/bash -p
+
+        printf '%s\\n' "$PATH"
+        """,
+        env={"PATH": "/dangerous"},
+    ) == "/custom/bin:/usr/bin"
+
+
+def test_opt_env_arbitrary_value(run_program):
+    assert run_program(
+        """
+        #!/usr/bin/exec-suid --env FOO=bar --env BAZ=quux -- /bin/bash -p
+
+        printf '%s %s\\n' "$FOO" "$BAZ"
+        """,
+        env={"FOO": "/dangerous"},
+    ) == "bar quux"
+
+
+def test_opt_env_duplicate_value(run_program):
+    assert run_program(
+        """
+        #!/usr/bin/exec-suid --env FOO=old --env FOO=new -- /bin/bash -p
+
+        printf '%s\\n' "$FOO"
+        """
+    ) == "new"
 
 
 def test_env_term(run_program):
@@ -24,29 +102,6 @@ def test_env_term(run_program):
         """,
         env={"TERM": "term-custom"},
     ) == "term-custom"
-
-
-def test_opt_environ_none(run_program):
-    result = run_program(
-        """
-        #!/usr/bin/exec-suid --environ=none -- /bin/bash -p
-
-        printf '%s\\n' "$TERM"
-        """,
-        env={"TERM": "term-custom"},
-    )
-    assert result != "term-custom"
-
-
-def test_opt_environ_all(run_program):
-    assert run_program(
-        """
-        #!/usr/bin/exec-suid --environ=all -- /bin/bash -p
-
-        printf '%s\\n' "$PATH"
-        """,
-        env={"PATH": "/dangerous"},
-    ) == "/dangerous"
 
 
 def test_env_passwd_fallback(run_program):


### PR DESCRIPTION
## Summary

- keep `--environ=none/all/safe` temporarily as deprecated compatibility options
- add repeated `--env KEY=VALUE` shebang overrides for explicit environment variables
- source the default safe `PATH` from `/etc/environment`, with a Debian/Ubuntu root PATH fallback
- skip `/etc/environment` PATH lookup when `--env PATH=...` is explicitly provided

## Rationale

`exec-suid` previously required `PATH` to be present in `/proc/1/environ`. That works when PID 1 is the container process, but it breaks in runtimes where PID 1 is platform infrastructure or a minimal init without image `ENV` values. `/etc/environment` is a better image-owned source for this value, and a fixed fallback keeps safe mode usable even when that file is absent.

The new `--env` option intentionally only supports explicit `KEY=VALUE` assignments. The shebang line is still split on whitespace, so values containing whitespace are intentionally not supported.

The fallback PATH is `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`, matching Debian/Ubuntu's root `ENV_SUPATH` without Ubuntu's snap-specific suffix. Python's `os.defpath` is narrower (`/bin:/usr/bin`), and Ubuntu sudo's `secure_path` adds `/snap/bin`, so the Debian root path is the better general-purpose default here.

## Validation

- `docker build -t exec-suid-env-pr /tmp/exec-suid-pr && docker run --rm exec-suid-env-pr` passes: 19 tests
- `git diff --check`

Note: `cargo fmt --check` was not applied because the existing upstream source is not rustfmt-formatted and rustfmt would rewrite unrelated lines.
